### PR TITLE
Enable CDN support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,9 +31,9 @@ module.exports = {
       type: "text"
     },
     cdn: {
-      label: "Enable CDN?",
+      label: "CDN",
       type: "enum",
-      values: ["No", "Yes"]
+      values: ["False", "True"]
     }
   },
   init: config => {
@@ -62,7 +62,10 @@ module.exports = {
               if (err) {
                 return reject(err);
               }
-              file.url = data.Location.replace(`${config.region}.digitaloceanspaces.com`,`${config.region}.${config.cdn === "Yes" ? "cdn." : ""}digitaloceanspaces.com`);
+              if (config.cdn === "True") {
+                data.Location.replace(`.digitaloceanspaces.com`, `.cdn.digitaloceanspaces.com`);
+              }
+              file.url = data.Location;
               resolve();
             }
           );

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ module.exports = {
                 return reject(err);
               }
               if (config.cdn === "True") {
-                data.Location.replace(`.digitaloceanspaces.com`, `.cdn.digitaloceanspaces.com`);
+                data.Location = data.Location.replace(`.digitaloceanspaces.com`, `.cdn.digitaloceanspaces.com`);
               }
               file.url = data.Location;
               resolve();

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ module.exports = {
     cdn: {
       label: "Enable CDN?",
       type: "enum",
-      values: ["Yes", "No"]
+      values: ["No", "Yes"]
     }
   },
   init: config => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-unused-vars */
 // Public node modules.
-const _ = require("lodash");
 const AWS = require("aws-sdk");
 
 module.exports = {
@@ -30,6 +29,11 @@ module.exports = {
     space: {
       label: "Space",
       type: "text"
+    },
+    cdn: {
+      label: "Enable CDN?",
+      type: "enum",
+      values: ["Yes", "No"]
     }
   },
   init: config => {
@@ -58,7 +62,7 @@ module.exports = {
               if (err) {
                 return reject(err);
               }
-              file.url = data.Location;
+              file.url = data.Location.replace(`${config.region}.digitaloceanspaces.com`,`${config.region}.${config.cdn === "Yes" ? "cdn." : ""}digitaloceanspaces.com`);
               resolve();
             }
           );


### PR DESCRIPTION
The changes made have added a config option alongside the preexisting authentication options. I've tested uploading with and without the CDN enabled, uploading was successful both times.

I'm not sure why lodash was included initially as it was unused and the provider functioned without it, if it is a requirement of Strapi it can easily be added back.